### PR TITLE
Create therapist practice website and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-Create a website that is used for a therapist that has multiple tabs. Whatever you think of the most essential tabs for a therapist's private practice with information, use placeholders use tailwind. CSS but use raw HTML and CSS with tailwind from a CDN because this is going to be hosted on GitHub pages. Fill in as much as you can. I'd like to be able to see something and start working right away
+# Serenity Path Therapy Website
+
+A single-page therapist private practice site with tabbed navigation built with semantic HTML, Tailwind CSS (via CDN), and a small script for interactive tab switching. The design highlights essential practice information so the site is ready for immediate content customization and GitHub Pages hosting.
+
+## Getting Started
+
+Open `index.html` in any modern browser. All styling is provided through the Tailwind CDN, so no build steps are required.
+
+## Page Sections
+
+- **Welcome:** Quick overview with a consultation call-to-action and testimonial highlights.
+- **Services:** Description of core offerings, fees, insurance information, and consultation details.
+- **About:** Therapist biography, professional highlights, and credentials.
+- **Approach:** Summary of modalities and what clients can expect in therapy.
+- **Resources:** Curated crisis, mindfulness, book, and community resources plus a client portal prompt.
+- **Contact:** Inquiry form with placeholder fields, office location, phone, email, and accessibility notes.
+
+## Next Steps
+
+- Replace placeholder copy with practice-specific language, credentials, and contact details.
+- Connect the "Client Portal" and "Send message" button to the desired scheduling or form service.
+- Add analytics, SEO metadata, and a custom domain configuration when deploying to GitHub Pages.
+
+## Deployment
+
+For GitHub Pages:
+
+1. Commit the repository to your GitHub account.
+2. Enable Pages in the repository settings (deploy from the main branch, `/root` directory).
+3. Your site will be available at `https://<username>.github.io/<repository>/` once the build completes.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,410 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Serenity Path Therapy</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.13/dist/tailwind.min.css"
+    />
+    <style>
+      .tab-content {
+        display: none;
+      }
+
+      .tab-content.active {
+        display: block;
+      }
+    </style>
+  </head>
+  <body class="bg-slate-50 text-slate-800">
+    <header class="bg-sky-100 border-b border-sky-200">
+      <div class="max-w-5xl mx-auto px-6 py-8 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <p class="text-sm uppercase tracking-wide text-sky-600 font-semibold">
+            Serenity Path Therapy
+          </p>
+          <h1 class="text-3xl font-bold text-slate-900">
+            Compassionate care for your journey
+          </h1>
+          <p class="text-slate-600 mt-2 max-w-xl">
+            Welcoming individuals, couples, and families seeking a calm, supportive space to explore healing and growth.
+          </p>
+        </div>
+        <div class="bg-white shadow-sm rounded-lg p-4 text-sm text-slate-600 border border-slate-200">
+          <p class="font-semibold text-slate-900">Office Hours</p>
+          <p>Monday – Friday: 9:00 AM – 6:00 PM</p>
+          <p>Saturday: By appointment</p>
+          <p>Telehealth sessions available</p>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-6 py-12">
+      <nav class="flex flex-wrap gap-2 text-sm">
+        <button data-tab="home" class="tab-button px-4 py-2 rounded-full bg-sky-600 text-white shadow-sm">
+          Welcome
+        </button>
+        <button data-tab="services" class="tab-button px-4 py-2 rounded-full bg-white text-slate-700 border border-slate-200">
+          Services
+        </button>
+        <button data-tab="about" class="tab-button px-4 py-2 rounded-full bg-white text-slate-700 border border-slate-200">
+          About
+        </button>
+        <button data-tab="approach" class="tab-button px-4 py-2 rounded-full bg-white text-slate-700 border border-slate-200">
+          Approach
+        </button>
+        <button data-tab="resources" class="tab-button px-4 py-2 rounded-full bg-white text-slate-700 border border-slate-200">
+          Resources
+        </button>
+        <button data-tab="contact" class="tab-button px-4 py-2 rounded-full bg-white text-slate-700 border border-slate-200">
+          Contact
+        </button>
+      </nav>
+
+      <section id="home" class="tab-content active">
+        <div class="grid gap-6 mt-10 md:grid-cols-2">
+          <div class="bg-white border border-slate-200 rounded-xl shadow-sm p-6">
+            <h2 class="text-2xl font-semibold text-slate-900">A place to begin again</h2>
+            <p class="mt-4 leading-relaxed text-slate-600">
+              Therapy is a collaborative process, and every session is tailored to your pace. Together we will identify what feels most pressing, clarify your goals, and create a plan that feels compassionate and sustainable.
+            </p>
+            <p class="mt-4 leading-relaxed text-slate-600">
+              Whether you are navigating anxiety, relationship changes, life transitions, or burnout, you will find support grounded in curiosity, respect, and evidence-based care.
+            </p>
+            <a
+              href="#contact"
+              class="inline-block mt-6 px-5 py-3 text-sm font-semibold text-white bg-sky-600 rounded-full shadow hover:bg-sky-500 transition"
+              data-tab-link="contact"
+            >
+              Request a consultation
+            </a>
+          </div>
+          <div class="bg-sky-50 border border-sky-100 rounded-xl p-6">
+            <h3 class="text-xl font-semibold text-slate-900">What clients share</h3>
+            <ul class="mt-4 space-y-4 text-slate-600">
+              <li>
+                “I finally have space to breathe and name what I need.”
+              </li>
+              <li>
+                “Sessions give me practical tools and a reminder that change is possible.”
+              </li>
+              <li>
+                “I feel seen, supported, and encouraged to care for myself.”
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section id="services" class="tab-content">
+        <div class="mt-10 space-y-8">
+          <div class="bg-white border border-slate-200 rounded-xl shadow-sm p-6">
+            <h2 class="text-2xl font-semibold text-slate-900">Therapeutic Services</h2>
+            <p class="mt-4 text-slate-600">
+              Services are currently available in-person at the downtown studio and through secure telehealth sessions for clients located within the state.
+            </p>
+            <div class="mt-6 grid gap-6 md:grid-cols-2">
+              <div>
+                <h3 class="text-lg font-semibold text-slate-900">Individual Therapy</h3>
+                <p class="mt-2 text-slate-600">
+                  Support for anxiety, depression, grief, stress, identity exploration, and major life transitions.
+                </p>
+              </div>
+              <div>
+                <h3 class="text-lg font-semibold text-slate-900">Couples & Relationship Work</h3>
+                <p class="mt-2 text-slate-600">
+                  Guided communication, conflict resolution, and reconnection for couples of all identities and stages.
+                </p>
+              </div>
+              <div>
+                <h3 class="text-lg font-semibold text-slate-900">Adolescent Support</h3>
+                <p class="mt-2 text-slate-600">
+                  Space for teens to process anxiety, self-esteem, and academic pressures with family collaboration as needed.
+                </p>
+              </div>
+              <div>
+                <h3 class="text-lg font-semibold text-slate-900">Workshops & Groups</h3>
+                <p class="mt-2 text-slate-600">
+                  Seasonal groups and retreats focused on mindfulness, burnout prevention, and healing through creativity.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div class="grid gap-6 md:grid-cols-3">
+            <div class="bg-sky-50 border border-sky-100 rounded-xl p-5">
+              <h4 class="font-semibold text-slate-900">Session Fee</h4>
+              <p class="mt-2 text-slate-600">$160 per 50-minute session</p>
+              <p class="text-xs text-slate-500 mt-4">Sliding scale openings are reviewed monthly.</p>
+            </div>
+            <div class="bg-sky-50 border border-sky-100 rounded-xl p-5">
+              <h4 class="font-semibold text-slate-900">Insurance</h4>
+              <p class="mt-2 text-slate-600">
+                Out-of-network documentation provided for client reimbursement. HSA/FSA cards accepted.
+              </p>
+            </div>
+            <div class="bg-sky-50 border border-sky-100 rounded-xl p-5">
+              <h4 class="font-semibold text-slate-900">Consultations</h4>
+              <p class="mt-2 text-slate-600">
+                Complimentary 20-minute video consultation to explore fit and next steps.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="about" class="tab-content">
+        <div class="mt-10 grid gap-8 md:grid-cols-[2fr,3fr]">
+          <div class="bg-white border border-slate-200 rounded-xl shadow-sm p-6">
+            <h2 class="text-2xl font-semibold text-slate-900">Meet Leah Morgan, LMFT</h2>
+            <p class="mt-4 text-slate-600">
+              Leah is a licensed marriage and family therapist specializing in relational wellness, trauma-informed care, and creative expression as a pathway to healing.
+            </p>
+            <p class="mt-4 text-slate-600">
+              With over ten years of experience in community mental health and private practice, Leah integrates somatic awareness, attachment theory, and narrative therapy to support sustainable change.
+            </p>
+            <p class="mt-4 text-slate-600">
+              Outside the therapy room, Leah enjoys watercolor painting, restorative yoga, and tending to a small rooftop garden.
+            </p>
+          </div>
+          <div class="bg-sky-50 border border-sky-100 rounded-xl p-6">
+            <h3 class="text-xl font-semibold text-slate-900">Professional Highlights</h3>
+            <ul class="mt-4 space-y-3 text-slate-600">
+              <li>
+                Licensed in the state of Washington (LF123456)
+              </li>
+              <li>
+                Master’s in Marriage & Family Therapy, Pacific Northwest University
+              </li>
+              <li>
+                Certified EMDR practitioner and Gottman Level II clinician
+              </li>
+              <li>
+                Presenter on burnout recovery, trauma-sensitive mindfulness, and LGBTQ+ affirming care
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section id="approach" class="tab-content">
+        <div class="mt-10 space-y-8">
+          <div class="bg-white border border-slate-200 rounded-xl shadow-sm p-6">
+            <h2 class="text-2xl font-semibold text-slate-900">Therapeutic Approach</h2>
+            <p class="mt-4 text-slate-600">
+              Every client brings their own lived experience, strengths, and hopes to therapy. Leah collaborates with clients to determine which tools feel most supportive, drawing from evidence-based modalities and an anti-oppressive, culturally responsive lens.
+            </p>
+          </div>
+
+          <div class="grid gap-6 md:grid-cols-3">
+            <div class="bg-sky-50 border border-sky-100 rounded-xl p-5">
+              <h3 class="font-semibold text-slate-900">Mindful Awareness</h3>
+              <p class="mt-3 text-slate-600">
+                Grounding practices, body awareness, and breath work to build resilience and restore nervous system balance.
+              </p>
+            </div>
+            <div class="bg-sky-50 border border-sky-100 rounded-xl p-5">
+              <h3 class="font-semibold text-slate-900">Narrative Exploration</h3>
+              <p class="mt-3 text-slate-600">
+                Working together to re-author the stories that influence identity, relationships, and next steps.
+              </p>
+            </div>
+            <div class="bg-sky-50 border border-sky-100 rounded-xl p-5">
+              <h3 class="font-semibold text-slate-900">Creative Integration</h3>
+              <p class="mt-3 text-slate-600">
+                Optional use of journaling, art, and movement when words alone don’t capture the full experience.
+              </p>
+            </div>
+          </div>
+
+          <div class="bg-white border border-slate-200 rounded-xl shadow-sm p-6">
+            <h3 class="text-xl font-semibold text-slate-900">What to expect in our work together</h3>
+            <ol class="mt-4 list-decimal list-inside space-y-2 text-slate-600">
+              <li>Collaborative goal setting during the first sessions.</li>
+              <li>Regular check-ins to adjust pacing and focus.</li>
+              <li>Practical tools to practice between sessions.</li>
+              <li>Compassionate accountability and celebration of progress.</li>
+            </ol>
+          </div>
+        </div>
+      </section>
+
+      <section id="resources" class="tab-content">
+        <div class="mt-10 space-y-8">
+          <div class="bg-white border border-slate-200 rounded-xl shadow-sm p-6">
+            <h2 class="text-2xl font-semibold text-slate-900">Support Between Sessions</h2>
+            <p class="mt-4 text-slate-600">
+              These resources are curated to complement therapy and deepen your practice of care between sessions. They are not a substitute for professional help during a crisis.
+            </p>
+            <ul class="mt-6 space-y-4 text-slate-600">
+              <li>
+                <span class="font-semibold text-slate-900">Crisis Support:</span> National Crisis Hotline 988 &bull; Crisis Text Line: Text HOME to 741741
+              </li>
+              <li>
+                <span class="font-semibold text-slate-900">Mindfulness:</span> Ten Percent Happier app, Insight Timer, Body Scan audio practice
+              </li>
+              <li>
+                <span class="font-semibold text-slate-900">Books:</span> <em>Burnout</em> by Emily and Amelia Nagoski, <em>Atlas of the Heart</em> by Brené Brown
+              </li>
+              <li>
+                <span class="font-semibold text-slate-900">Community:</span> Local LGBTQ+ affirming support groups (Seattle Pride Center), grief circles, and creative arts workshops
+              </li>
+            </ul>
+          </div>
+
+          <div class="bg-sky-50 border border-sky-100 rounded-xl p-6">
+            <h3 class="text-xl font-semibold text-slate-900">Client Portal</h3>
+            <p class="mt-4 text-slate-600">
+              Existing clients can log into the secure portal to review session notes, request appointment changes, and access shared resources.
+            </p>
+            <a
+              href="#"
+              class="inline-flex items-center gap-2 mt-6 px-4 py-2 rounded-full text-sm font-semibold text-sky-700 border border-sky-200 hover:bg-sky-100"
+            >
+              Launch portal <span aria-hidden="true">&rarr;</span>
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <section id="contact" class="tab-content">
+        <div class="mt-10 grid gap-8 md:grid-cols-[1.25fr,1fr]">
+          <div class="bg-white border border-slate-200 rounded-xl shadow-sm p-6">
+            <h2 class="text-2xl font-semibold text-slate-900">Contact</h2>
+            <p class="mt-4 text-slate-600">
+              Share a few details below and our team will reach out within two business days to schedule a consultation.
+            </p>
+            <form class="mt-6 grid gap-4">
+              <label class="block">
+                <span class="text-sm font-semibold text-slate-700">Name</span>
+                <input
+                  type="text"
+                  placeholder="Your full name"
+                  class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 focus:border-sky-500 focus:ring focus:ring-sky-200"
+                />
+              </label>
+              <label class="block">
+                <span class="text-sm font-semibold text-slate-700">Email</span>
+                <input
+                  type="email"
+                  placeholder="you@example.com"
+                  class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 focus:border-sky-500 focus:ring focus:ring-sky-200"
+                />
+              </label>
+              <label class="block">
+                <span class="text-sm font-semibold text-slate-700">Support Focus</span>
+                <select class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 focus:border-sky-500 focus:ring focus:ring-sky-200">
+                  <option>Individual Therapy</option>
+                  <option>Couples Therapy</option>
+                  <option>Adolescent Support</option>
+                  <option>Group/Workshop Interest</option>
+                </select>
+              </label>
+              <label class="block">
+                <span class="text-sm font-semibold text-slate-700">How can we help?</span>
+                <textarea
+                  rows="4"
+                  placeholder="Share anything that feels important for us to know."
+                  class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 focus:border-sky-500 focus:ring focus:ring-sky-200"
+                ></textarea>
+              </label>
+              <button
+                type="submit"
+                class="mt-2 inline-flex items-center justify-center gap-2 rounded-full bg-sky-600 px-5 py-3 text-sm font-semibold text-white hover:bg-sky-500"
+              >
+                Send message
+              </button>
+            </form>
+          </div>
+
+          <div class="bg-sky-50 border border-sky-100 rounded-xl p-6 space-y-5">
+            <div>
+              <h3 class="font-semibold text-slate-900">Location</h3>
+              <p class="mt-2 text-slate-600">
+                425 Pine Street, Suite 300<br />
+                Seattle, WA 98101
+              </p>
+            </div>
+            <div>
+              <h3 class="font-semibold text-slate-900">Phone</h3>
+              <p class="mt-2 text-slate-600">(206) 555-0198</p>
+            </div>
+            <div>
+              <h3 class="font-semibold text-slate-900">Email</h3>
+              <p class="mt-2 text-slate-600">hello@serenitypaththerapy.com</p>
+            </div>
+            <div>
+              <h3 class="font-semibold text-slate-900">Parking & Access</h3>
+              <p class="mt-2 text-slate-600">
+                Street parking and nearby garage parking available. Elevator and step-free access throughout the building.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="bg-slate-900 text-slate-100">
+      <div class="max-w-5xl mx-auto px-6 py-10 grid gap-8 md:grid-cols-2">
+        <div>
+          <p class="text-sm uppercase tracking-wide text-sky-400 font-semibold">
+            Serenity Path Therapy
+          </p>
+          <p class="mt-3 text-sm text-slate-300">
+            Trauma-informed, LGBTQ+ affirming therapy for individuals, couples, and families across Washington state.
+          </p>
+        </div>
+        <div class="grid gap-2 text-sm text-slate-300">
+          <p>Office: 425 Pine Street, Suite 300, Seattle, WA 98101</p>
+          <p>Phone: (206) 555-0198</p>
+          <p>Email: hello@serenitypaththerapy.com</p>
+          <p class="text-slate-500">&copy; <span id="year"></span> Serenity Path Therapy. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      const buttons = document.querySelectorAll('.tab-button');
+      const tabContents = document.querySelectorAll('.tab-content');
+      const yearElement = document.getElementById('year');
+
+      function activateTab(tabId) {
+        tabContents.forEach((content) => {
+          content.classList.toggle('active', content.id === tabId);
+        });
+
+        buttons.forEach((button) => {
+          const isActive = button.dataset.tab === tabId;
+          button.classList.toggle('bg-sky-600', isActive);
+          button.classList.toggle('text-white', isActive);
+          button.classList.toggle('shadow-sm', isActive);
+          button.classList.toggle('bg-white', !isActive);
+          button.classList.toggle('text-slate-700', !isActive);
+          button.classList.toggle('border', !isActive);
+          button.classList.toggle('border-slate-200', !isActive);
+        });
+      }
+
+      buttons.forEach((button) => {
+        button.addEventListener('click', () => {
+          activateTab(button.dataset.tab);
+        });
+      });
+
+      document.querySelectorAll('[data-tab-link]').forEach((link) => {
+        link.addEventListener('click', (event) => {
+          event.preventDefault();
+          const targetTab = link.getAttribute('data-tab-link');
+          activateTab(targetTab);
+          document.getElementById(targetTab).scrollIntoView({ behavior: 'smooth' });
+        });
+      });
+
+      if (yearElement) {
+        yearElement.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a Tailwind-powered single-page therapist practice site with tabbed sections for key content
- document current features, setup steps, deployment, and suggested follow-up actions in the README

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4f9591a90832799776ae600466778